### PR TITLE
/docs fix for hard coded POST value

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -106,7 +106,7 @@ var renderRoutes = exports.renderRoutes = function( format, name, items, templat
        // POST
        
        html += ('<div class="content">');
-       html += ('<span class="verb">POST</span> <span class="url">/echo<br>');
+       html += ('<span class="verb">POST</span> <span class="url">/'+method+'<br>');
        html += ('<div class="curl">curl -X POST -d "' + sampleCurlArgs.substr(1, sampleCurlArgs.length) + '" ' + items.endpoint + '/' + method + '</div>');
        html += ('You can also post JSON...<br/>');
        html += ('<div class="curl">curl -X POST -d "' + JSON.stringify(sampleCurlJSON) + '" ' + items.endpoint + '/' + method + '</div>');


### PR DESCRIPTION
All methods always said /echo for POST description. It was not using the 'method' variable.
