### PR TITLE
Sanitize JSONP namespace (XSS)

### DIFF
--- a/examples/standalone/server.js
+++ b/examples/standalone/server.js
@@ -1,5 +1,5 @@
-var webservice = require('../lib/webservice'),
-    demoModule = require('./modules/demoModule'),
+var webservice = require('../../lib/webservice'),
+    demoModule = require('../sample_modules/demoModule'),
     colors     = require('colors');
 
 webservice.createServer(demoModule).listen(8080);

--- a/lib/createRouter.js
+++ b/lib/createRouter.js
@@ -276,6 +276,12 @@ var createMetaRoutes = exports.createMetaRoutes = function (module, routes){
 }
 
 var JSONPWRAP = exports.JSONPWRAP = function(namespace, data) {
+
+  // only do JSONPWRAP if callback don't have any special character
+  if (!namespace.match(/^[\w-]+$/))
+    return data;
+
+
   return 'function ' + namespace + '() {\
     return "' + data + '"\
   }';

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "./lib/webservice",
   "dependencies": {
     "journey": "= 0.4.0-pre",
-    "colors": ">= 0.5.0"
+    "colors": ">= 0.5.0",
+    "eyes": "0.1.x"    
   },
   "devDependencies" : {
     "vows": "0.5.x",


### PR DESCRIPTION
Jsonp is being processed without sanitize the callback value from the user.

To prevent XSS this fix will not run JSONPWRAP if the callback value have any special char's
